### PR TITLE
upgrade mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   "author": "Michael Cereda",
   "license": "MIT",
   "devDependencies": {
-    "babel-cli": "^6.11.4",
-    "babel-preset-es2015": "^6.9.0",
+    "babel-cli": "^6.14.0",
+    "babel-preset-es2015": "^6.14.0",
     "chai": "^3.5.0",
-    "mocha": "^2.5.3"
+    "mocha": "^3.0.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes outdated dependency warning on npm install.

``` bash
npm WARN deprecated to-iso-string@0.0.2: to-iso-string has been deprecated, use @segment/to-iso-string instead.
npm WARN deprecated jade@0.26.3: Jade has been renamed to pug, please install the latest version of pug instead of jade
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```
